### PR TITLE
fix: Ruby 2.4.4 compatibility.

### DIFF
--- a/lib/rails_async_migrations.rb
+++ b/lib/rails_async_migrations.rb
@@ -8,6 +8,7 @@ begin
 rescue LoadError
 end
 
+require 'rails_async_migrations/define_method_in'
 require 'rails_async_migrations/connection/active_record'
 require 'rails_async_migrations/config'
 require 'rails_async_migrations/migration'

--- a/lib/rails_async_migrations/define_method_in.rb
+++ b/lib/rails_async_migrations/define_method_in.rb
@@ -1,0 +1,10 @@
+module RailsAsyncMigrations
+  module DefineMethodIn
+    # `klass.define_method(...)` does not work in Ruby 2.4. Work around.
+    def define_method_in(klass, name, &block)
+      klass.class_exec {
+        define_method(name, &block)
+      }
+    end
+  end
+end

--- a/lib/rails_async_migrations/migration/give.rb
+++ b/lib/rails_async_migrations/migration/give.rb
@@ -1,6 +1,8 @@
 module RailsAsyncMigrations
   module Migration
     class Give
+      include RailsAsyncMigrations::DefineMethodIn
+      
       attr_reader :resource_class, :method_name
 
       def initialize(resource_class, method_name)
@@ -17,7 +19,7 @@ module RailsAsyncMigrations
       def restore_original_method
         if valid?
           Take.new(resource_class, method_name).suspend_take do
-            resource_class.define_method(method_name, &method_clone)
+            define_method_in(resource_class, method_name, &method_clone)
           end
         end
       end

--- a/lib/rails_async_migrations/migration/take.rb
+++ b/lib/rails_async_migrations/migration/take.rb
@@ -4,6 +4,8 @@
 module RailsAsyncMigrations
   module Migration
     class Take
+      include RailsAsyncMigrations::DefineMethodIn
+
       attr_reader :resource_class, :method_name
 
       def initialize(resource_class, method_name)
@@ -39,7 +41,7 @@ module RailsAsyncMigrations
       end
 
       def preserve_method_logics
-        resource_class.define_method(clone_method_name, &captured_method)
+        define_method_in(resource_class, clone_method_name, &captured_method)
       end
 
       def captured_method
@@ -47,7 +49,7 @@ module RailsAsyncMigrations
       end
 
       def overwrite_method
-        resource_class.define_method(method_name, &overwrite_closure)
+        define_method_in(resource_class, method_name, &overwrite_closure)
       end
 
       def overwrite_closure

--- a/spec/rails_async_migrations/migration/take_spec.rb
+++ b/spec/rails_async_migrations/migration/take_spec.rb
@@ -1,10 +1,12 @@
 RSpec.describe RailsAsyncMigrations::Migration::Take do
+  include RailsAsyncMigrations::DefineMethodIn
+  
   let(:resource_class) { FakeClass }
   let(:resource_instance) { resource_class.new }
   let(:method) { :free_method }
   let(:instance) { described_class.new(resource_class, method) }
 
-  let(:change_to_it_passed) { resource_class.define_method(method, -> { 'it passed' }) }
+  let(:change_to_it_passed) { define_method_in(resource_class, method) { 'it passed' } }
 
   before { change_to_it_passed }
   subject { instance.perform }

--- a/spec/rails_async_migrations/migration_spec.rb
+++ b/spec/rails_async_migrations/migration_spec.rb
@@ -1,9 +1,11 @@
 RSpec.describe RailsAsyncMigrations::Migration do
+  include RailsAsyncMigrations::DefineMethodIn
+  
   let(:resource_class) { FakeClass }
   let(:instance) { resource_class.new }
   let(:method) { :free_method }
-  let(:change_to_true) { resource_class.define_method(method, -> { true }) }
-  let(:change_to_false) { resource_class.define_method(method, -> { false }) }
+  let(:change_to_true) { define_method_in(resource_class, method) { true } }
+  let(:change_to_false) { define_method_in(resource_class, method) { false } }
 
   # we reset the class each time
   # as RSpec won't hot-reload it


### PR DESCRIPTION
It seems `klass.define_method(...)` does not work in Ruby 2.4.4. It works in Ruby 2.5.5. Work around it using `klass.class_exec { define_method(...) }`.

Thank you for this wonderful module! If it works, it will get me out of a pretty bad migration hole I've dug for myself. And make big migrations much easier going forward.